### PR TITLE
Just use an env var BASE_URL to build absolute URLs incl host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ CREATE DATABASE
 postgres=#
 ```
 
+Allow passwordless database connections locally, or give your DB user a password
+and set the DATABASE_URL environment variable accordingly.
+
+Set the following environment variables:
+
+```
+RECAPTCHA_KEY=...
+RECAPTCHA_SECRET=...
+```
+
+Initialise and run.
+
 ```
 python manage.py migrate
 python manage.py createsuperuser
@@ -69,6 +81,7 @@ Development
 * Put SCSS stylesheets into ``contactmps/static/stylesheets/app.scss``
 * Install new asset packs with Bower: ``bower install -Sp package-to-install``
 * Get better debugging with ``python manage.py runserver_plus``
+
 
 Production deployment
 ---------------------
@@ -89,7 +102,8 @@ dokku config:set  DJANGO_DEBUG=false \
                   DJANGO_EMAIL_HOST_PASSOWRD=the sendgrind password \
                   DJANGO_SEND_EMAILS=True \
                   RECAPTCHA_KEY=... \
-                  RECAPTCHA_SECRET=...
+                  RECAPTCHA_SECRET=... \
+                  BASE_URL=https://production.url.com/
 git push dokku master
 ```
 

--- a/contactmps/context_processors.py
+++ b/contactmps/context_processors.py
@@ -9,6 +9,7 @@ def general(request):
     """
 
     info = {
+        'BASE_URL': settings.BASE_URL,
         'SITE_NAME': 'Contact Members of Parliament',
         'SITE_DESCRIPTION': "You have the opportunity to lobby Members of Parliament. Just because South Africa has a proportional representation electoral system for provincial and national government, doesn't mean that members of parliament don't represent citizens of South Africa. MPs are allocated to Constituency Offices where they should be available to interact with members of the public."
     }

--- a/contactmps/settings.py
+++ b/contactmps/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.7/ref/settings/
 import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
+BASE_URL = os.environ.get('BASE_URL', 'http://localhost:8000/')
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/

--- a/contactmps/templates/email-detail.html
+++ b/contactmps/templates/email-detail.html
@@ -4,7 +4,7 @@
 {% block title %}I, {{ email.from_name }}, sent a message to {{ email.to_person.name }} MP!{% endblock %}
 {% block og_title %}I, {{ email.from_name }}, sent a message to {{ email.to_person.name }} MP!{% endblock %}
 {% block tweet %}I, {{ email.from_name }}, sent a message to {{ email.to_person.name }} MP!{% endblock %}
-{% block whatsapp_msg %}I, {{ email.from_name|urlencode }}, sent a message to {{ email.to_person.name|urlencode }} MP! Will you? {{ request.build_absolute_uri|strip_qs|urlencode }}wa/{% endblock %}
+{% block whatsapp_msg %}I, {{ email.from_name|urlencode }}, sent a message to {{ email.to_person.name|urlencode }} MP! Will you? {{ BASE_URL|urlencode }}wa/{% endblock %}
 
 {% block content %}
 

--- a/contactmps/templates/layout.html
+++ b/contactmps/templates/layout.html
@@ -63,12 +63,12 @@
           {% block social_sharing %}
 
           {% if is_mobile %}
-          <a href="whatsapp://send?text={% block whatsapp_msg %}{{ request.build_absolute_uri|strip_qs|urlencode }}wa/{% endblock whatsapp_msg %}" data-action="share/whatsapp/share"><img src="/static/images/whatsapp-logo.png" alt="WhatsApp" height="32"></a>
+          <a href="whatsapp://send?text={% block whatsapp_msg %}{{ BASE_URL|urlencode }}wa/{% endblock whatsapp_msg %}" data-action="share/whatsapp/share"><img src="/static/images/whatsapp-logo.png" alt="WhatsApp" height="32"></a>
           {% endif %}
 
-          <iframe src="https://www.facebook.com/plugins/share_button.php?href={{ request.build_absolute_uri|strip_qs|urlencode }}fb/&layout=button_count&size=small&mobile_iframe=true&appId=1879108499081905&width=88&height=20" width="88" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
+          <iframe src="https://www.facebook.com/plugins/share_button.php?href={{ BASE_URL|urlencode }}fb/&layout=button_count&size=small&mobile_iframe=true&appId=1879108499081905&width=88&height=20" width="88" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowTransparency="true"></iframe>
 
-          <a href="https://twitter.com/share" class="twitter-share-button" data-text="{% block tweet %}{{ SITE_NAME }}{% endblock %}" data-show-count="false" data-url="{{ request.build_absolute_uri|strip_qs }}tw/">Tweet</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+          <a href="https://twitter.com/share" class="twitter-share-button" data-text="{% block tweet %}{{ SITE_NAME }}{% endblock %}" data-show-count="false" data-url="{{ BASE_URL }}tw/">Tweet</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
           <div><a href="/embed.html">Embed this on your site</a></div>
           {% endblock social_sharing %}


### PR DESCRIPTION
We've wasted enough time on URLs. Some sharing sites warn about redirects.
request.build_absolute_uri builds http URLs even if the request was via HTTPS
Looks like good writeup of config options at
https://security.stackexchange.com/questions/8964/trying-to-make-a-django-based-site-use-https-only-not-sure-if-its-secure
but let's just stop faffing