### PR TITLE
copy email POST handler for ajax API

### DIFF
--- a/contactmps/urls.py
+++ b/contactmps/urls.py
@@ -22,6 +22,9 @@ urlpatterns = [
     url(r'^email/$', csrf_exempt(views.email), name='email'),
     url(r'^email/(?P<secure_id>[a-z0-9-]+)/$', cache_page(API_CACHE_SECS)(views.email_detail), name='email-detail'),
 
+    # API
+    url(r'^api/v1/email/$', csrf_exempt(views.api_email), name='api-email'),
+
     # UTM - This rather strict regex is part of ensuring we don't let people just
     # inject what they like into a response we give. Think before changing.
     url(r'^campaign/%s/(?P<utm_medium>[a-z]{2})/$' % settings.CAMPAIGN,


### PR DESCRIPTION
for example, call with:
```javascript
var submitForm = function() {
  jQuery.ajax('/api/v1/email/', {
    type: 'POST',
    data: {
      person: 7720,
      name: 'Fred Bloggs',
      email: '',
      body: 'Dear Baleka, stuff.',
      subject: 'Re: Secret Ballot in Vote of No Confidence in Jacob Zuma as President of the Republic',
      gRecaptchaResponse: '2398f49f293fjfj20fj'
    },
    success: function(data) {
      console.info("success", data);
    },
    error: function(jqXHR, textStatus, errorThrown) {
      console.error(jqXHR, textStatus, errorThrown, jqXHR.responseText);
    }
  });
};
```